### PR TITLE
Fixing issue when block < slice size.

### DIFF
--- a/src/main/java/com/ibm/reflex/client/ReflexChannel.java
+++ b/src/main/java/com/ibm/reflex/client/ReflexChannel.java
@@ -57,7 +57,8 @@ public abstract class ReflexChannel {
 	}	
 	
 	public void fetchBuffer(SocketChannel channel, ReflexHeader header, ByteBuffer buffer) throws IOException{
-		buffer.clear().limit(header.getCount()*blockSize);
+		// do not modify the buffer here, as this buffer has the right
+		// position and limit set.
 		while (buffer.hasRemaining()) {
 			if (channel.read(buffer) < 0) {
 				throw new IOException("error when reading header from socket");


### PR DESCRIPTION
When the block size is less than the slice size, then
a single slice is passed to multiple outstanding I/O
request with their position and limit set. So do _not_
clear a buffer whose position might be set to a
non-zero offset.