### PR TITLE
remove buffer clear in fetchBuffer

### DIFF
--- a/src/main/java/com/ibm/reflex/client/ReflexChannel.java
+++ b/src/main/java/com/ibm/reflex/client/ReflexChannel.java
@@ -57,7 +57,6 @@ public abstract class ReflexChannel {
 	}	
 	
 	public void fetchBuffer(SocketChannel channel, ReflexHeader header, ByteBuffer buffer) throws IOException{
-		buffer.clear().limit(header.getCount()*blockSize);
 		while (buffer.hasRemaining()) {
 			if (channel.read(buffer) < 0) {
 				throw new IOException("error when reading header from socket");


### PR DESCRIPTION
To support the case where buffer or slicesize is larger than blocksize (i.e., when a request consumes multiple blocks), we should not reset the buffer position when fetching this buffer during completion processing. Thanks to @animeshtrivedi  and @PepperJo for finding this.